### PR TITLE
Show help overlay automatically on initial load

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -19,6 +19,8 @@ type Team = {
   worms: Worm[];
 };
 
+let initialHelpShown = false;
+
 export class Game {
   canvas: HTMLCanvasElement;
   ctx: CanvasRenderingContext2D;
@@ -77,6 +79,11 @@ export class Game {
     this.updateCursor();
 
     this.helpOverlay = new HelpOverlay();
+
+    if (!initialHelpShown) {
+      this.showHelp();
+      initialHelpShown = true;
+    }
 
   }
 


### PR DESCRIPTION
## Summary
- show the help overlay once when the app first boots so newcomers see controls immediately
- ensure subsequent game restarts keep the overlay closed by guarding with a module-level flag

## Testing
- npx tsc -p tsconfig.json --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d920ba51b0832cb0c644643cea226c