### PR TITLE
Render help topics with highlighted titles

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -26,6 +26,7 @@ export const COLORS = {
   healthRed: "#ff5555",
   healthGreen: "#5aff7a",
   power: "#ffcc00",
+  helpTitle: "#ffd85c",
 };
 
 export const WORLD = {


### PR DESCRIPTION
## Summary
- restructure the help overlay topics to store a title and description for each entry
- highlight topic headers in a golden tone while keeping description text styling intact
- add a dedicated color constant and custom wrapping logic for help topic descriptions

## Testing
- npx tsc -p tsconfig.json --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68db83806520832c9e5fa35ebfef2e2a