### PR TITLE
Remove unused HUD and worm snapshot types

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -78,27 +78,6 @@ export const GAMEPLAY = {
 
 export type PredictedPoint = { x: number; y: number; alpha: number };
 
-export type WormSnapshot = {
-  x: number;
-  y: number;
-  health: number;
-  team: TeamId;
-  alive: boolean;
-};
-
-export type HudState = {
-  currentTeam: TeamId;
-  weapon: WeaponType;
-  turnTimeLeftMs: number;
-  wind: number;
-  charging: boolean;
-  charge01: number;
-  redTeamHealth: number;
-  blueTeamHealth: number;
-  message: string | null;
-  predicted: PredictedPoint[];
-};
-
 export const clamp = (v: number, min: number, max: number) =>
   Math.max(min, Math.min(max, v));
 


### PR DESCRIPTION
## Summary
- remove unused `WormSnapshot` and `HudState` type exports from `definitions.ts`

## Testing
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68de3d2f0240832c9fbb41645f46b9ec