### PR TITLE
Enable GitHub Pages deploys for pull request previews

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -52,6 +52,7 @@ jobs:
     name: Deploy
     needs: build
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     environment:
       name: ${{ github.event_name == 'pull_request' && format('github-pages-pr-{0}', github.event.pull_request.number) || 'github-pages' }}
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,7 +14,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: 'pages-${{ github.event.pull_request.number || github.ref }}'
   cancel-in-progress: true
 
 jobs:
@@ -50,7 +50,6 @@ jobs:
 
   deploy:
     name: Deploy
-    if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -62,3 +62,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          preview: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,7 +53,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment:
-      name: github-pages
+      name: ${{ github.event_name == 'pull_request' && format('github-pages-pr-{0}', github.event.pull_request.number) || 'github-pages' }}
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Configure Pages

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Worms-Style Tactics</title>
+    <title>Wormish!</title>
     <link rel="stylesheet" href="./src/styles/index.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>


### PR DESCRIPTION
## Summary
- allow the GitHub Pages deployment job to execute for pull request events to produce preview URLs
- scope the workflow concurrency group to the PR number or ref so independent deployments do not cancel each other

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68de3dac0f4c832c8014fccacbf2ee26