### PR TITLE
Revert sniper aim behaviour adjustments

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -24,7 +24,6 @@ import { TeamManager, type Team } from "./game/team-manager";
 import {
   computeAimInfo,
   fireWeapon,
-  handleWeaponChanged,
   predictTrajectory,
   resolveCharge01,
   shouldPredictPath,
@@ -212,18 +211,9 @@ export class Game {
     }
 
     // Weapon switching
-    const previousWeapon = this.state.weapon;
     if (this.keyAny(["Digit1"])) this.state.setWeapon(WeaponType.Bazooka);
     if (this.keyAny(["Digit2"])) this.state.setWeapon(WeaponType.HandGrenade);
     if (this.keyAny(["Digit3"])) this.state.setWeapon(WeaponType.Rifle);
-    if (this.state.weapon !== previousWeapon) {
-      handleWeaponChanged({
-        previous: previousWeapon,
-        next: this.state.weapon,
-        input: this.input,
-        activeWorm: this.activeWorm,
-      });
-    }
     // Update cursor visibility when weapon changes
     this.updateCursor();
 

--- a/src/game/weapon-system.ts
+++ b/src/game/weapon-system.ts
@@ -33,13 +33,6 @@ export type TrajectoryContext = {
   height: number;
 };
 
-export type WeaponChangeContext = {
-  previous: WeaponType;
-  next: WeaponType;
-  input: Input;
-  activeWorm: Worm;
-};
-
 export function computeAimInfo({ input, state, activeWorm }: AimContext): AimInfo {
   const aimWorm = activeWorm;
   let dx = input.mouseX - aimWorm.x;
@@ -192,14 +185,6 @@ export function predictTrajectory({
   return pts;
 }
 
-export function handleWeaponChanged({ previous, next, input, activeWorm }: WeaponChangeContext) {
-  if (next === WeaponType.Rifle && previous !== WeaponType.Rifle) {
-    snapRifleAimToDefault(input, activeWorm);
-  } else if (previous === WeaponType.Rifle && next !== WeaponType.Rifle) {
-    input.clearMouseWarp();
-  }
-}
-
 export function shouldPredictPath(state: GameState): boolean {
   return state.phase === "aim" && state.charging;
 }
@@ -208,21 +193,3 @@ export function resolveCharge01(state: GameState): number {
   return state.getCharge01(nowMs());
 }
 
-function snapRifleAimToDefault(input: Input, worm: Worm) {
-  const dx = input.mouseX - worm.x;
-  const dy = input.mouseY - worm.y;
-  const distanceFromWorm = Math.hypot(dx, dy);
-  const horizontalFraction = distanceFromWorm > 0 ? Math.abs(dx) / distanceFromWorm : 0;
-
-  let direction = 0;
-  if (horizontalFraction > 0.2) {
-    direction = dx >= 0 ? 1 : -1;
-  }
-  if (direction === 0) {
-    direction = Math.random() < 0.5 ? -1 : 1;
-  }
-
-  const radius = GAMEPLAY.rifle.aimRadius;
-  const offset = radius / Math.sqrt(2);
-  input.warpMouseTo(worm.x + direction * offset, worm.y - offset);
-}

--- a/src/rendering/game-rendering.ts
+++ b/src/rendering/game-rendering.ts
@@ -177,12 +177,11 @@ export function renderAimHelpers({
     ctx.restore();
   }
 
-  const isRifle = state.weapon === WeaponType.Rifle;
+  const chSize = 8;
+  const crossCol = state.weapon === WeaponType.Rifle ? "#ffd84d" : "#fff";
+  drawCrosshair(ctx, aim.targetX, aim.targetY, chSize, crossCol, 2);
 
-  if (isRifle) {
-    const chSize = 8;
-    const crossColor = COLORS.blue;
-    drawCrosshair(ctx, aim.targetX, aim.targetY, chSize, crossColor, 2);
+  if (state.weapon === WeaponType.Rifle) {
     ctx.save();
     ctx.globalAlpha = 0.15;
     ctx.beginPath();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,11 +3,6 @@ export class Input {
   private keysDown = new Set<string>();
   private keysPressed = new Set<string>();
 
-  private rawMouseX = 0;
-  private rawMouseY = 0;
-  private mouseOffsetX = 0;
-  private mouseOffsetY = 0;
-
   private canvas: HTMLCanvasElement | null = null;
 
   mouseX = 0;
@@ -44,10 +39,8 @@ export class Input {
     const canvas = this.canvas;
     if (canvas) {
       const rect = canvas.getBoundingClientRect();
-      this.rawMouseX = (e.clientX - rect.left) * (canvas.width / rect.width);
-      this.rawMouseY = (e.clientY - rect.top) * (canvas.height / rect.height);
-      this.mouseX = this.rawMouseX + this.mouseOffsetX;
-      this.mouseY = this.rawMouseY + this.mouseOffsetY;
+      this.mouseX = (e.clientX - rect.left) * (canvas.width / rect.width);
+      this.mouseY = (e.clientY - rect.top) * (canvas.height / rect.height);
     }
   };
 
@@ -74,7 +67,6 @@ export class Input {
   private readonly blurHandler = () => {
     this.keysDown.clear();
     this.mouseDown = false;
-    this.clearMouseWarp();
   };
 
   attach(canvas: HTMLCanvasElement) {
@@ -110,27 +102,12 @@ export class Input {
     this.mouseDown = false;
     this.mouseJustPressed = false;
     this.mouseJustReleased = false;
-    this.clearMouseWarp();
   }
 
   update() {
     this.mouseJustPressed = false;
     this.mouseJustReleased = false;
     this.keysPressed.clear();
-  }
-
-  warpMouseTo(x: number, y: number) {
-    this.mouseOffsetX = x - this.rawMouseX;
-    this.mouseOffsetY = y - this.rawMouseY;
-    this.mouseX = x;
-    this.mouseY = y;
-  }
-
-  clearMouseWarp() {
-    this.mouseOffsetX = 0;
-    this.mouseOffsetY = 0;
-    this.mouseX = this.rawMouseX;
-    this.mouseY = this.rawMouseY;
   }
 
   isDown(code: string) {


### PR DESCRIPTION
## Summary
- remove the weapon-change hook that warped the rifle aim direction
- delete the input mouse warp helpers and the rifle snap logic that depended on them
- restore the original crosshair rendering so all weapons reuse the default cursor styling

## Testing
- npx tsc -p tsconfig.json --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e9c1cbe844832c8f4eccb14ec91b80