### PR TITLE
Draw rifle crosshair only when needed

### DIFF
--- a/src/rendering/game-rendering.ts
+++ b/src/rendering/game-rendering.ts
@@ -177,11 +177,11 @@ export function renderAimHelpers({
     ctx.restore();
   }
 
-  const chSize = 8;
-  const crossCol = state.weapon === WeaponType.Rifle ? "#ffd84d" : "#fff";
-  drawCrosshair(ctx, aim.targetX, aim.targetY, chSize, crossCol, 2);
-
   if (state.weapon === WeaponType.Rifle) {
+    const chSize = 8;
+    const crossCol = "#ffd84d";
+    drawCrosshair(ctx, aim.targetX, aim.targetY, chSize, crossCol, 2);
+
     ctx.save();
     ctx.globalAlpha = 0.15;
     ctx.beginPath();


### PR DESCRIPTION
## Summary
- stop rendering the in-game crosshair for non-rifle weapons so the OS cursor remains visible
- keep the rifle aiming radius overlay and crosshair unchanged

## Testing
- npx tsc -p tsconfig.json --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e9c4022044832ca73b47650eee1efa