### PR TITLE
Add camera shake effect to explosive weapons

### DIFF
--- a/src/entities/terrain.ts
+++ b/src/entities/terrain.ts
@@ -1,5 +1,6 @@
 import { WORLD, COLORS, clamp, randRange } from "../definitions";
 import { groundTiles } from "../assets";
+
 export class Terrain {
   width: number;
   height: number;
@@ -8,18 +9,30 @@ export class Terrain {
   ctx: CanvasRenderingContext2D;
   heightMap: number[];
   private tilePattern: CanvasPattern | null = null;
+  private readonly horizontalPadding: number;
+  private readonly totalWidth: number;
 
-  constructor(width: number, height: number) {
+  constructor(width: number, height: number, options?: { horizontalPadding?: number }) {
     this.width = width | 0;
     this.height = height | 0;
-    this.solid = new Uint8Array(this.width * this.height);
+    this.horizontalPadding = Math.max(0, Math.floor(options?.horizontalPadding ?? 0));
+    this.totalWidth = this.width + this.horizontalPadding * 2;
+    this.solid = new Uint8Array(this.totalWidth * this.height);
     this.canvas = document.createElement("canvas");
-    this.canvas.width = this.width;
+    this.canvas.width = this.totalWidth;
     this.canvas.height = this.height;
     const ctx = this.canvas.getContext("2d");
     if (!ctx) throw new Error("Terrain 2D context missing");
     this.ctx = ctx;
-    this.heightMap = new Array(this.width).fill(this.height * 0.7);
+    this.heightMap = new Array(this.totalWidth).fill(this.height * 0.7);
+  }
+
+  get worldLeft() {
+    return -this.horizontalPadding;
+  }
+
+  get worldRight() {
+    return this.width + this.horizontalPadding;
   }
 
   generate(seed = Math.random()) {
@@ -37,21 +50,22 @@ export class Terrain {
     const k2 = randRange(0.01, 0.02);
     const k3 = randRange(0.02, 0.04);
 
-    for (let x = 0; x < this.width; x++) {
+    for (let x = 0; x < this.totalWidth; x++) {
+      const worldX = x - this.horizontalPadding;
       const h =
         base +
-        Math.sin(x * k1 + seed * 10) * amp1 +
-        Math.sin(x * k2 + seed * 20) * amp2 +
-        Math.sin(x * k3 + seed * 30) * amp3 +
+        Math.sin(worldX * k1 + seed * 10) * amp1 +
+        Math.sin(worldX * k2 + seed * 20) * amp2 +
+        Math.sin(worldX * k3 + seed * 30) * amp3 +
         randRange(-10, 10);
       this.heightMap[x] = clamp(h, this.height * 0.35, this.height * 0.9);
     }
 
     // Build solid mask
-    for (let x = 0; x < this.width; x++) {
+    for (let x = 0; x < this.totalWidth; x++) {
       const groundY = Math.floor(this.heightMap[x]!);
       for (let y = 0; y < this.height; y++) {
-        this.setSolid(x, y, y >= groundY ? 1 : 0);
+        this.setSolidInternal(x, y, y >= groundY ? 1 : 0);
       }
     }
 
@@ -63,7 +77,7 @@ export class Terrain {
 
   private redrawVisual() {
     const ctx = this.ctx;
-    ctx.clearRect(0, 0, this.width, this.height);
+    ctx.clearRect(0, 0, this.totalWidth, this.height);
     // Dirt gradient
     const grad = ctx.createLinearGradient(0, this.height * 0.5, 0, this.height);
     grad.addColorStop(0, COLORS.dirt);
@@ -72,10 +86,10 @@ export class Terrain {
     ctx.fillStyle = grad;
     ctx.beginPath();
     ctx.moveTo(0, this.height);
-    for (let x = 0; x < this.width; x++) {
+    for (let x = 0; x < this.totalWidth; x++) {
       ctx.lineTo(x, this.heightMap[x]!);
     }
-    ctx.lineTo(this.width, this.height);
+    ctx.lineTo(this.totalWidth, this.height);
     ctx.closePath();
     ctx.fill();
 
@@ -88,7 +102,7 @@ export class Terrain {
     ctx.lineWidth = 3;
     ctx.strokeStyle = COLORS.grassHighlight;
     ctx.beginPath();
-    for (let x = 0; x < this.width; x += 1) {
+    for (let x = 0; x < this.totalWidth; x += 1) {
       const y = Math.floor(this.heightMap[x]!) - 1;
       ctx.moveTo(x, y - 1);
       ctx.lineTo(x + 2, y - 1 - Math.random() * 2);
@@ -100,7 +114,7 @@ export class Terrain {
     ctx.save();
     ctx.fillStyle = COLORS.grass;
     ctx.beginPath();
-    for (let x = 0; x < this.width; x++) {
+    for (let x = 0; x < this.totalWidth; x++) {
       const y = Math.floor(this.heightMap[x]!);
       ctx.rect(x, y - 5, 2, 6);
     }
@@ -109,47 +123,62 @@ export class Terrain {
     ctx.restore();
   }
 
- // Load tile image and overlay pattern once ready
- private loadTile(url: string) {
-   const img = new Image();
-   img.onload = () => {
-     const pat = this.ctx.createPattern(img, "repeat");
-     if (pat) {
-       this.tilePattern = pat;
-       // Overlay pattern over existing ground while preserving carved holes
-       this.applyTilePattern();
-     }
-   };
-   img.src = url;
- }
+  // Load tile image and overlay pattern once ready
+  private loadTile(url: string) {
+    const img = new Image();
+    img.onload = () => {
+      const pat = this.ctx.createPattern(img, "repeat");
+      if (pat) {
+        this.tilePattern = pat;
+        // Overlay pattern over existing ground while preserving carved holes
+        this.applyTilePattern();
+      }
+    };
+    img.src = url;
+  }
 
- private applyTilePattern() {
-   if (!this.tilePattern) return;
-   const ctx = this.ctx;
-   ctx.save();
-   ctx.globalCompositeOperation = "source-in";
-   ctx.fillStyle = this.tilePattern;
-   ctx.fillRect(0, 0, this.width, this.height);
-   ctx.restore();
+  private applyTilePattern() {
+    if (!this.tilePattern) return;
+    const ctx = this.ctx;
+    ctx.save();
+    ctx.globalCompositeOperation = "source-in";
+    ctx.fillStyle = this.tilePattern;
+    ctx.fillRect(0, 0, this.totalWidth, this.height);
+    ctx.restore();
 
-   // Re-add grass overlay above the tiled fill
-   this.drawGrass();
- }
+    // Re-add grass overlay above the tiled fill
+    this.drawGrass();
+  }
 
- setSolid(x: number, y: number, value: 0 | 1) {
-    if (x < 0 || y < 0 || x >= this.width || y >= this.height) return;
-    this.solid[y * this.width + x] = value;
+  private toInternalX(x: number) {
+    return Math.round(x + this.horizontalPadding);
+  }
+
+  private setSolidInternal(ix: number, y: number, value: 0 | 1) {
+    if (ix < 0 || y < 0 || ix >= this.totalWidth || y >= this.height) return;
+    this.solid[y * this.totalWidth + ix] = value;
+  }
+
+  setSolid(x: number, y: number, value: 0 | 1) {
+    if (y < 0 || y >= this.height) return;
+    const ix = this.toInternalX(x);
+    if (ix < 0 || ix >= this.totalWidth) return;
+    this.solid[y * this.totalWidth + ix] = value;
   }
 
   isSolid(x: number, y: number) {
-    if (x < 0 || y < 0 || x >= this.width || y >= this.height) return false;
-    return this.solid[y * this.width + x] === 1;
+    if (y < 0 || y >= this.height) return false;
+    const ix = this.toInternalX(x);
+    if (ix < 0 || ix >= this.totalWidth) return false;
+    return this.solid[y * this.totalWidth + ix] === 1;
   }
 
   carveCircle(cx: number, cy: number, r: number) {
-    const x0 = Math.max(0, Math.floor(cx - r));
+    const minX = Math.floor(this.worldLeft);
+    const maxX = Math.ceil(this.worldRight);
+    const x0 = Math.max(minX, Math.floor(cx - r));
     const y0 = Math.max(0, Math.floor(cy - r));
-    const x1 = Math.min(this.width - 1, Math.ceil(cx + r));
+    const x1 = Math.min(maxX, Math.ceil(cx + r));
     const y1 = Math.min(this.height - 1, Math.ceil(cy + r));
     const rr = r * r;
     for (let y = y0; y <= y1; y++) {
@@ -165,7 +194,7 @@ export class Terrain {
     this.ctx.save();
     this.ctx.globalCompositeOperation = "destination-out";
     this.ctx.beginPath();
-    this.ctx.arc(cx, cy, r, 0, Math.PI * 2);
+    this.ctx.arc(cx + this.horizontalPadding, cy, r, 0, Math.PI * 2);
     this.ctx.fill();
     this.ctx.restore();
   }
@@ -206,9 +235,11 @@ export class Terrain {
   private circleOverlapsSolidGrid(cx: number, cy: number, r: number): boolean {
     // Robust rectangle-distance check: for each solid cell intersecting the circle's AABB,
     // compute the closest point on the cell rectangle to the circle center and compare distance.
-    const x0 = Math.max(0, Math.floor(cx - r - 1));
+    const minX = Math.floor(this.worldLeft);
+    const maxX = Math.ceil(this.worldRight);
+    const x0 = Math.max(minX, Math.floor(cx - r - 1));
     const y0 = Math.max(0, Math.floor(cy - r - 1));
-    const x1 = Math.min(this.width - 1, Math.ceil(cx + r + 1));
+    const x1 = Math.min(maxX, Math.ceil(cx + r + 1));
     const y1 = Math.min(this.height - 1, Math.ceil(cy + r + 1));
     const rr = r * r;
     for (let y = y0; y <= y1; y++) {
@@ -264,6 +295,6 @@ export class Terrain {
   }
 
   render(ctx: CanvasRenderingContext2D) {
-    ctx.drawImage(this.canvas, 0, 0);
+    ctx.drawImage(this.canvas, -this.horizontalPadding, 0);
   }
 }

--- a/src/game/weapon-system.ts
+++ b/src/game/weapon-system.ts
@@ -10,6 +10,8 @@ export type AimContext = {
   input: Input;
   state: GameState;
   activeWorm: Worm;
+  cameraOffsetX?: number;
+  cameraOffsetY?: number;
 };
 
 export type FireContext = {
@@ -33,10 +35,18 @@ export type TrajectoryContext = {
   height: number;
 };
 
-export function computeAimInfo({ input, state, activeWorm }: AimContext): AimInfo {
+export function computeAimInfo({
+  input,
+  state,
+  activeWorm,
+  cameraOffsetX,
+  cameraOffsetY,
+}: AimContext): AimInfo {
   const aimWorm = activeWorm;
-  let dx = input.mouseX - aimWorm.x;
-  let dy = input.mouseY - aimWorm.y;
+  const pointerX = input.mouseX - (cameraOffsetX ?? 0);
+  const pointerY = input.mouseY - (cameraOffsetY ?? 0);
+  let dx = pointerX - aimWorm.x;
+  let dy = pointerY - aimWorm.y;
   if (state.weapon === WeaponType.Rifle) {
     const len = Math.hypot(dx, dy) || 1;
     const r = GAMEPLAY.rifle.aimRadius;

--- a/src/rendering/game-rendering.ts
+++ b/src/rendering/game-rendering.ts
@@ -20,17 +20,22 @@ export type AimInfo = {
 export function renderBackground(
   ctx: CanvasRenderingContext2D,
   width: number,
-  height: number
+  height: number,
+  padding = 0
 ) {
-  const g = ctx.createLinearGradient(0, 0, 0, height);
+  const left = -padding;
+  const top = -padding;
+  const drawWidth = width + padding * 2;
+  const drawHeight = height + padding * 2;
+  const g = ctx.createLinearGradient(0, top, 0, top + drawHeight);
   g.addColorStop(0, COLORS.bgSkyTop);
   g.addColorStop(1, COLORS.bgSkyBottom);
   ctx.fillStyle = g;
-  ctx.fillRect(0, 0, width, height);
+  ctx.fillRect(left, top, drawWidth, drawHeight);
 
   ctx.fillStyle = COLORS.water;
   const waterH = 30;
-  ctx.fillRect(0, height - waterH, width, waterH);
+  ctx.fillRect(left, height - waterH, drawWidth, waterH + padding);
 }
 
 export type RenderHudOptions = {


### PR DESCRIPTION
## Summary
- add a decaying camera shake effect that triggers on bazooka and grenade explosions and offsets rendering
- extend terrain generation with horizontal padding so shaking keeps the landscape filling the screen
- adjust aiming and background rendering to respect the camera offset during shake

## Testing
- npx tsc -p tsconfig.json --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68ecaec0ad04832c901684d16d730220