### PR TITLE
Adjust grenade balance and camera shake

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -58,8 +58,8 @@ export const GAMEPLAY = {
     maxPower: 940,
     fuseMs: 3000,
     restitution: 0.35,
-    explosionRadius: 52,
-    damage: 90,
+    explosionRadius: 68,
+    damage: 108,
   },
   // Rifle: straight-line shot (no gravity), small ground dent, heavy direct damage
   rifle: {

--- a/src/game.ts
+++ b/src/game.ts
@@ -302,7 +302,7 @@ export class Game {
     // Terrain hole
     this.terrain.carveCircle(x, y, radius);
 
-    if (cause === WeaponType.Bazooka || cause === WeaponType.HandGrenade) {
+    if (cause === WeaponType.HandGrenade) {
       this.triggerCameraShake(radius * 0.7);
     }
 


### PR DESCRIPTION
## Summary
- increase the hand grenade's explosion radius and damage to make it more impactful
- restrict camera shake feedback to hand grenade detonations, leaving bazooka shots steady

## Testing
- npx tsc -p tsconfig.json --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68ecb35f6f88832c8aaa930e2d06d9a5